### PR TITLE
Fix a bug that the project cannot compile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 main: main.c culzss  gpu_compress deculzss  gpu_decompress decompression
-	gcc -g -L /usr/local/cuda/lib64/ -lcudart -lpthread -o main main.c culzss.o gpu_compress.o deculzss.o gpu_decompress.o decompression.o
+	gcc -g -L /usr/local/cuda/lib64/ -o main main.c culzss.o gpu_compress.o deculzss.o gpu_decompress.o decompression.o -lcudart -lpthread
 
 decompression: 	decompression.c decompression.h
 	gcc -g  -c -lpthread -o decompression.o decompression.c


### PR DESCRIPTION
gcc will not find the libraries if we put -l before -o.
